### PR TITLE
[SM-311] PID config validation when already exists signal in template

### DIFF
--- a/internal/core/commands/create_pid.go
+++ b/internal/core/commands/create_pid.go
@@ -40,7 +40,10 @@ type CreatePidCommandResponse struct {
 
 func (h CreatePidCommandHandler) Execute(ctx context.Context, req *CreatePidCommandRequest) (*CreatePidCommandResponse, error) {
 
-	exists, err := models.PidConfigs(models.PidConfigWhere.SignalName.EQ(req.SignalName)).Exists(ctx, h.DBS().Reader)
+	exists, err := models.PidConfigs(
+		models.PidConfigWhere.SignalName.EQ(req.SignalName),
+		models.PidConfigWhere.TemplateName.EQ(req.TemplateName),
+	).Exists(ctx, h.DBS().Reader)
 	if err != nil {
 		return nil, &exceptions.InternalError{
 			Err: errors.Wrapf(err, "error checking if pid config exists: %s", req.TemplateName),


### PR DESCRIPTION
# Proposed Changes
- PID config validation when already exists signal in template
### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->