### PR TITLE
SM-1078 Rework how we do grpc connections, identity api configurable

### DIFF
--- a/charts/vehicle-signal-decoding/values-prod.yaml
+++ b/charts/vehicle-signal-decoding/values-prod.yaml
@@ -26,6 +26,7 @@ env:
   DEFINITIONS_GRPC_ADDR: device-definitions-api-prod:8086
   DEVICE_DATA_GRPC_ADDR: device-data-api-prod:8086
   AWS_CANDUMPS_BUCKET_NAME: dimo-network-canbus-dump-prod
+  IDENTITY_API_URL: https://identity-api.dimo.zone/query
 ingress:
   enabled: true
   className: nginx

--- a/charts/vehicle-signal-decoding/values.yaml
+++ b/charts/vehicle-signal-decoding/values.yaml
@@ -51,6 +51,7 @@ env:
   DEFINITIONS_GRPC_ADDR: device-definitions-api-dev:8086
   DEVICE_DATA_GRPC_ADDR: device-data-api-dev:8086
   AWS_CANDUMPS_BUCKET_NAME: dimo-network-canbus-dump-dev
+  IDENTITY_API_URL: https://identity-api.dev.dimo.zone/query
 service:
   type: ClusterIP
   ports:

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -29,4 +29,5 @@ type Settings struct {
 	DeviceDataGRPCAddr    string `yaml:"DEVICE_DATA_GRPC_ADDR"`
 	JwtKeySetURL          string `yaml:"JWT_KEY_SET_URL"`
 	UsersGRPCAddr         string `yaml:"USERS_GRPC_ADDR"`
+	IdentityAPIURL        string `yaml:"IDENTITY_API_URL"` //nolint
 }

--- a/internal/controllers/device_config_controller.go
+++ b/internal/controllers/device_config_controller.go
@@ -296,6 +296,7 @@ func (d *DeviceConfigController) GetConfigURLsFromVIN(c *fiber.Ctx) error {
 	if err != nil {
 		definitionResp, err := d.deviceDefSvc.DecodeVIN(c.Context(), vin)
 		if err != nil {
+			d.log.Err(err).Str("func", "GetConfigURLsFromVIN").Msgf("failed to DecodeVIN when trying to get configs")
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": fmt.Sprintf("could not decode VIN, contact support if you're sure this is valid VIN: %s", vin)})
 		}
 
@@ -343,7 +344,7 @@ func (d *DeviceConfigController) GetConfigURLsFromEthAddr(c *fiber.Ctx) error {
 		return c.JSON(directConfig)
 	}
 
-	vehicle, err := d.identityAPI.QueryIdentityAPIForVehicle(address)
+	vehicle, err := d.identityAPI.GetVehicleByDeviceAddr(address)
 	if err != nil {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": fmt.Sprintf("no minted vehicle for device EthAddr: %s", ethAddr)})
 	}

--- a/internal/core/services/device_definitions_service.go
+++ b/internal/core/services/device_definitions_service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	grpc "google.golang.org/grpc"
+
 	pgrpc "github.com/DIMO-Network/device-definitions-api/pkg/grpc"
 	"github.com/DIMO-Network/vehicle-signal-decoding/internal/infrastructure/exceptions"
 )
@@ -19,10 +21,10 @@ type deviceDefinitionsService struct {
 	vinDecoderClient  pgrpc.VinDecoderServiceClient
 }
 
-func NewDeviceDefinitionsService(definitionsClient pgrpc.DeviceDefinitionServiceClient, vinDecoderClient pgrpc.VinDecoderServiceClient) DeviceDefinitionsService {
+func NewDeviceDefinitionsService(definitionsConn *grpc.ClientConn) DeviceDefinitionsService {
 	return &deviceDefinitionsService{
-		definitionsClient: definitionsClient,
-		vinDecoderClient:  vinDecoderClient,
+		definitionsClient: pgrpc.NewDeviceDefinitionServiceClient(definitionsConn),
+		vinDecoderClient:  pgrpc.NewVinDecoderServiceClient(definitionsConn),
 	}
 }
 

--- a/internal/core/services/user_device_service.go
+++ b/internal/core/services/user_device_service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	grpc "google.golang.org/grpc"
+
 	"github.com/pkg/errors"
 
 	common2 "github.com/ethereum/go-ethereum/common"
@@ -25,9 +27,9 @@ type userDeviceService struct {
 	devicesClient pb.UserDeviceServiceClient
 }
 
-func NewUserDeviceService(devicesGrpcClient pb.UserDeviceServiceClient) UserDeviceService {
+func NewUserDeviceService(devicesGrpcConn *grpc.ClientConn) UserDeviceService {
 	return &userDeviceService{
-		devicesClient: devicesGrpcClient,
+		devicesClient: pb.NewUserDeviceServiceClient(devicesGrpcConn),
 	}
 }
 

--- a/internal/gateways/mocks/identity_api_mock.go
+++ b/internal/gateways/mocks/identity_api_mock.go
@@ -39,17 +39,17 @@ func (m *MockIdentityAPI) EXPECT() *MockIdentityAPIMockRecorder {
 	return m.recorder
 }
 
-// QueryIdentityAPIForVehicle mocks base method.
-func (m *MockIdentityAPI) QueryIdentityAPIForVehicle(ethAddress common.Address) (*gateways.VehicleInfo, error) {
+// GetVehicleByDeviceAddr mocks base method.
+func (m *MockIdentityAPI) GetVehicleByDeviceAddr(ethAddress common.Address) (*gateways.VehicleInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryIdentityAPIForVehicle", ethAddress)
+	ret := m.ctrl.Call(m, "GetVehicleByDeviceAddr", ethAddress)
 	ret0, _ := ret[0].(*gateways.VehicleInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// QueryIdentityAPIForVehicle indicates an expected call of QueryIdentityAPIForVehicle.
-func (mr *MockIdentityAPIMockRecorder) QueryIdentityAPIForVehicle(ethAddress any) *gomock.Call {
+// GetVehicleByDeviceAddr indicates an expected call of GetVehicleByDeviceAddr.
+func (mr *MockIdentityAPIMockRecorder) GetVehicleByDeviceAddr(ethAddress any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryIdentityAPIForVehicle", reflect.TypeOf((*MockIdentityAPI)(nil).QueryIdentityAPIForVehicle), ethAddress)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVehicleByDeviceAddr", reflect.TypeOf((*MockIdentityAPI)(nil).GetVehicleByDeviceAddr), ethAddress)
 }


### PR DESCRIPTION
# Proposed Changes
- identity api can now be used in dev or prod, via values config
- rework how grpc connections are made, refactor, standardize

### Impacted Routes
<!-- Will this pull request change or implement any new API Routes? -->

### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->